### PR TITLE
feat: export wall face to dxf with layers

### DIFF
--- a/notebooks/wall.py
+++ b/notebooks/wall.py
@@ -35,53 +35,68 @@ show(details.middle_hole())
 
 # %%
 height, width = 2400, 600
-face = cq.Sketch().rect(width, height)
+outside = cq.Sketch().rect(width, height)
 
 def bowtie_pair_points():
     for x in (-width/2, width/2):
         for y in range(-height//2 + 300, height//2, 600):
             yield x, y
 
-face.push(bowtie_pair_points())
-face.face(details.bowtie_pair(), mode='s')
+outside.push(bowtie_pair_points())
+outside.face(details.bowtie_pair(), mode='s')
 
 def slot_pairs_points():
     for x in (-width/2, width/2):
         for y in range(-height//2 + 600, height//2, 600):
             yield x, y
 
-face.push(slot_pairs_points())
-face.face(details.slot_pair(), mode='s')
+outside.push(slot_pairs_points())
+outside.face(details.slot_pair(), mode='s')
 
 def top_and_bottom_bowtie_points():
     for x in (-194.9, 0, 194.9):
         for y in (-height/2, height/2):
             yield x, y
 
-face.push(top_and_bottom_bowtie_points())
-face.face(details.bowtie(), mode='s')
+outside.push(top_and_bottom_bowtie_points())
+outside.face(details.bowtie(), mode='s')
 
 def corner_points():
     for x in (-width/2, width/2):
         for y in (-height/2, height/2):
             yield x, y
 
-face.push(corner_points()).face(details.corner(), mode='s').reset()
+outside.push(corner_points()).face(details.corner(), mode='s').reset()
+
+p = cq.Workplane("XY").placeSketch(outside).extrude(18)
 
 def middle_hole_points():
     for y in range(-height//2 + 600, height//2, 600):
         yield 0, y
 
+inside = cq.Sketch()
+inside.push(middle_hole_points()).face(details.middle_hole()).reset()
 
-face.push(middle_hole_points()).face(details.middle_hole(), mode='s').reset()
+p = p.faces(">Z").placeSketch(inside).cutThruAll()
 
-p = cq.Workplane("XY").placeSketch(face).extrude(18)
 #cq.exporters.export(p, "SKYLARK250_WALL-M-face.step", opt={"write_pcurves": False})
-#cq.exporters.export(cq.Workplane("XY").add(face.faces().val()), "SKYLARK250_WALL-M-face.dxf")
 show(p, reset_camera=Camera.KEEP)
 
 # 5_ANYTOOL_HALF_MILL_9MM_IN green
-# 3_ANYTOOL_CUTTHROUGH_INSID cyan
-# 4_ANYTOOL_CUTTHROUGH_OUTSI blue
 
 # %%
+# https://cadquery.readthedocs.io/en/latest/classreference.html#cadquery.occ_impl.exporters.dxf.DxfDocument
+
+from cadquery.occ_impl.exporters.dxf import DxfDocument
+dxf = DxfDocument()
+blue = outside.wires().offset(-0.25, mode='i').reset().clean()
+cyan = inside.wires().offset(0.25, mode='a').reset().clean()
+blue_w = cq.Workplane("XY").add(blue.faces().vals())
+cyan_w = cq.Workplane("XY").add(cyan.faces().vals())
+dxf.add_layer("4_ANYTOOL_CUTTHROUGH_OUTSI", color=5)
+dxf.add_shape(blue_w, "4_ANYTOOL_CUTTHROUGH_OUTSI")
+dxf.add_layer("3_ANYTOOL_CUTTHROUGH_INSID", color=4)
+dxf.add_shape(cyan_w, "3_ANYTOOL_CUTTHROUGH_INSID")
+dxf.document.saveas("SKYLARK250_WALL-M-face.dxf")
+
+show(p, blue_w, cyan_w)


### PR DESCRIPTION
In pursuit of being able to generate the cnc cut files directly, dxf layers are added to mirror the convention of current skylark cut files.

The outside outline is made smaller:
![image](https://github.com/zwn/cadquery-skylark/assets/1130051/6b233ea3-9408-4111-a8d2-9744227ff731)

The inside outline is made larger:
![image](https://github.com/zwn/cadquery-skylark/assets/1130051/b2e1d61a-3cd0-4363-87e8-6faa9eb52830)

This is how LibreCad shows the layers:
![image](https://github.com/zwn/cadquery-skylark/assets/1130051/504541be-6299-4ff3-bdd4-d08c1c29c7d4)

These are the colors as shown in LibreCad:
![image](https://github.com/zwn/cadquery-skylark/assets/1130051/4fecda55-242f-4c42-9ab3-80d0c324a507)

