### PR TITLE
fix: add missing slots to certain wall heights

### DIFF
--- a/src/cadquery_skylark/wall_c.py
+++ b/src/cadquery_skylark/wall_c.py
@@ -33,6 +33,12 @@ def outside(width, height) -> cq.Sketch:
     s = cq.Sketch().rect(width, height)
     s.push(_slot_pairs_points(width / 2, height)).face(_slot_pair(), mode="s")
     s.push(_slot_pairs_points(-width / 2, height)).face(_slot_pair_service(), mode="s")
+
+    rest = height % 600
+    if rest > 200:
+        s.push([(width / 2, height // 2 - rest / 2)]).face(details.t_slot(100), mode="s")
+        s.push([(-width / 2, height // 2 - rest / 2)]).face(details.t_slot(100, 56 * 2), mode="s")
+
     s.push(_top_and_bottom_slot_point(width, height)).face(details.t_slot(60), angle=90, mode="s")
     return s.reset()
 


### PR DESCRIPTION
Wall height that were not multiple of 600mm need to have additional slots to mirror the upstream design correctly.

Wrong:

![image](https://github.com/zwn/cadquery-skylark/assets/1130051/37d27236-2e0f-4957-92cc-6bed91a73e8d)

Corrected:

![image](https://github.com/zwn/cadquery-skylark/assets/1130051/518addc9-98fc-405e-a9a2-7e707f31d17d)
