### PR TITLE
feat: center all parts

### DIFF
--- a/src/cadquery_skylark/common.py
+++ b/src/cadquery_skylark/common.py
@@ -16,3 +16,8 @@ def to_dxf(layers: tuple[cq.Sketch, ...]) -> dxf.DxfDocument:
     doc.add_layer("5_ANYTOOL_HALF_MILL_9MM_IN", color=3)
     doc.add_shape(green_w, "5_ANYTOOL_HALF_MILL_9MM_IN")
     return doc
+
+
+def recenter(shape: cq.Shape):
+    bb = shape.BoundingBox()
+    return shape.translate(-bb.center)

--- a/src/cadquery_skylark/wall_a.py
+++ b/src/cadquery_skylark/wall_a.py
@@ -1,6 +1,6 @@
 import cadquery as cq
 
-from . import details
+from . import details, common
 
 
 mm = int
@@ -103,7 +103,7 @@ def make_part(height: mm) -> cq.Solid:
     p = p.faces(">Z").workplane(centerOption="CenterOfBoundBox")
     p = p.placeSketch(half_s).cutBlind(-18 / 2)
 
-    return p.findSolid()
+    return common.recenter(p.findSolid())
 
 
 def make_cnc(height: mm):

--- a/src/cadquery_skylark/wall_b.py
+++ b/src/cadquery_skylark/wall_b.py
@@ -1,6 +1,6 @@
 import cadquery as cq
 
-from cadquery_skylark import details
+from cadquery_skylark import details, common
 
 
 def outside(x_len, y_len) -> cq.Sketch:
@@ -22,7 +22,7 @@ def make_part() -> cq.Solid:
     x_len, y_len = 600, 250 + 2 * 18
     outline_s = outside(x_len, y_len)
     p = cq.Workplane("XY").placeSketch(outline_s).extrude(18)
-    return p.clean().findSolid()
+    return common.recenter(p.findSolid())
 
 
 def make_cnc():

--- a/src/cadquery_skylark/wall_c.py
+++ b/src/cadquery_skylark/wall_c.py
@@ -1,6 +1,6 @@
 import cadquery as cq
 
-from . import details
+from . import details, common
 
 mm = int
 
@@ -70,7 +70,7 @@ def make_part(height: mm) -> cq.Solid:
     p = cq.Workplane("XY").placeSketch(outside_s).extrude(18)
     p = p.faces(">Z").workplane(centerOption="CenterOfBoundBox")
     p = p.placeSketch(inside_s).cutThruAll()
-    return p.findSolid()
+    return common.recenter(p.findSolid())
 
 
 def make_cnc(height: mm):

--- a/src/cadquery_skylark/wall_d.py
+++ b/src/cadquery_skylark/wall_d.py
@@ -1,6 +1,6 @@
 import cadquery as cq
 
-from . import details, wall_a
+from . import details, wall_a, common
 
 from .wall_a import outside as outside
 
@@ -32,7 +32,7 @@ def make_part(height: mm) -> cq.Solid:
     p = p.faces(">Z").workplane(centerOption="CenterOfBoundBox")
     p = p.placeSketch(half_s).cutBlind(-18 / 2)
 
-    return p.findSolid()
+    return common.recenter(p.findSolid())
 
 
 def make_cnc(height: mm):


### PR DESCRIPTION
Make sure all parts are centered around the origin to give them predictable location (use bounding box center).